### PR TITLE
PackageInfo.g: add License field

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -12,6 +12,7 @@ PackageName := "PackageManager",
 Subtitle := "Easily download and install GAP packages",
 Version := "0.2.1",
 Date := "04/10/2018", # dd/mm/yyyy format
+License := "GPL-2.0-or-later",
 
 Persons := [
   rec(


### PR DESCRIPTION
Your package does not actually say what the license is: GPL 2 exactly, or "GPL 2 or later". I assume / hope for the latter, otherwise this PR needs to be changed.

It'd be good if you could also clarify this, by either prepending a variation of the following text to the `LICENSE` file, or adding it to a license section in the README.

> PackageManager is free software; you can redistribute it and/or modify
> it under the terms of the GNU General Public License as published by
> the Free Software Foundation; either version 2 of the License, or
> (at your option) any later version.
