### PR TITLE
Fix PKGMAN_CompileDir to work for out-of-tree builds

### DIFF
--- a/gap/PackageManager.gd
+++ b/gap/PackageManager.gd
@@ -235,7 +235,8 @@ PKGMAN_DownloadCmds := [ [ "wget", ["--quiet", "-O", "-"] ],
 PKGMAN_CurlIntReqVer :=
   First(PackageInfo("PackageManager")[1].Dependencies.SuggestedOtherPackages,
         item -> item[1] = "curlInterface")[2];
-PKGMAN_BuildPackagesScript := Filename(List(GAPInfo.RootPaths, Directory),
-                                       "bin/BuildPackages.sh");
+PKGMAN_BuildPackagesScript := Filename(DirectoriesLibrary("bin"),
+                                       "BuildPackages.sh");
+PKGMAN_Sysinfo := Filename(DirectoriesLibrary(""), "sysinfo.gap");
 PKGMAN_InstallQueue := [];      # Queue of dependencies to install
 PKGMAN_MarkedForInstall := [];  # Packages currently halfway through installing

--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -744,16 +744,16 @@ function(dir)
 
   # Check requirements, and prepare command
   pkg_dir := Filename(Directory(dir), "..");
-  scr := PKGMAN_BuildPackagesScript;
+  scr := PKGMAN_Sysinfo;
   if scr = fail then
-    Info(InfoPackageManager, 1, "No bin/BuildPackages.sh script available");
+    Info(InfoPackageManager, 1, "No sysinfo.gap found");
     return false;
   fi;
-  root := scr{[1 .. Length(scr) - Length("/bin/BuildPackages.sh")]};
+  root := scr{[1 .. Length(scr) - Length("/sysinfo.gap")]};
 
   # Call the script
   Info(InfoPackageManager, 3, "Running compilation script on ", dir, " ...");
-  exec := PKGMAN_Exec(pkg_dir, Concatenation(root, "/bin/BuildPackages.sh"),
+  exec := PKGMAN_Exec(pkg_dir, PKGMAN_BuildPackagesScript,
                       "--strict",
                       Concatenation("--with-gaproot=", root),
                       dir);


### PR DESCRIPTION
The BuildPackages.sh is always contained in the GAP source directory.
But the gaproot it expects as argument actually must point at the GAP
build directory, where sysinfo.gap is located. In regular GAP builds,
these two directories are the same. But the whole point of out-of-tree
builds is to allow for for a separate build dir.