### PR TITLE
Remove dependence on GAPDoc

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -76,8 +76,8 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.9",
-  NeededOtherPackages := [ [ "GAPDoc", ">= 1.6.1" ] ],
-  SuggestedOtherPackages := [ [ "curlInterface", ">= 2.1.0" ] ],
+  NeededOtherPackages := [],
+  SuggestedOtherPackages := [ [ "GAPDoc", ">= 1.6.1" ], [ "curlInterface", ">= 2.1.0" ] ],
   ExternalConditions := [ ],
 ),
 

--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -3,6 +3,15 @@
 #
 # Implementations
 #
+
+if not IsBoundGlobal("WHITESPACE") then
+  BindGlobal("WHITESPACE", " \n\t\r");
+fi;
+
+if not IsBoundGlobal("InfoGAPDoc") then
+  BindGlobal("InfoGAPDoc", fail);
+fi;
+
 InstallGlobalFunction(GetPackageURLs,
 function()
   local get, urls, line, items;
@@ -807,6 +816,10 @@ InstallGlobalFunction(PKGMAN_MakeDoc,
 function(dir)
   local last_infogapdoc, last_infowarning, makedoc_g, doc_dir, doc_make_doc,
         last_dir, str, exec;
+  if not IsPackageLoaded("GAPDoc") then
+    Info(InfoPackageManager, 1,
+         "GAPDoc package not found, skipping building the documentation...");
+  fi;
 
   # Mute GAPDoc
   last_infogapdoc := InfoLevel(InfoGAPDoc);


### PR DESCRIPTION
This resolves Issue #63 making it possible to load the packagemanager without having GAPDoc available, and then to subsequently install GAPDoc using the packagemanager. 