### PR TITLE
Also run `tst/test-without-texlive.g` in the CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,14 @@ jobs:
           )
           sudo apt-get install "${packages[@]}"
       - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v2
+      - name: "Run tst/testall.g"
+        uses: gap-actions/run-pkg-tests@v2
+        with:
+          GAP_TESTFILE: "tst/testall.g"
+      - name: "Run tst/test-without-texlive.g"
+        uses: gap-actions/run-pkg-tests@v2
+        with:
+          GAP_TESTFILE: "tst/test-without-texlive.g"
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v2
 


### PR DESCRIPTION
This test file seems to fail, so we should investigate it. If appropriate, we should ultimately merge this PR.

(I haven't investigated what this test file is about, so maybe this PR is totally inappropriate. But in resurrecting tests of the GAP package distribution, I noticed that this file was being run, and failing.)