### PR TITLE
do not call `Error` in `GetPackageURLs`

### DIFF
--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -39,7 +39,7 @@ function()
     elif Length(items) = 1 or Length(items) > 3
          or (Length(items) = 3 and items[2] <> "MOVE") then
       Info(InfoPackageManager, 1,
-           "PackageManager: GetPackageURLs: bad line:\n", line);
+           "PackageManager: GetPackageURLs: bad line:\n#I  ", line);
       return urls;
     fi;
     urls.(LowercaseString(items[1])) := items[Length(items)];

--- a/tst/PackageManager.tst
+++ b/tst/PackageManager.tst
@@ -171,11 +171,13 @@ false
 gap> default_url := PKGMAN_PackageInfoURLList;;
 gap> PKGMAN_PackageInfoURLList := "http://www.nothing.rubbish/abc.txt";;
 gap> GetPackageURLs();
-Error, PackageManager: GetPackageURLs: could not contact server
+#I  PackageManager: GetPackageURLs: could not contact server
+rec( success := false )
 gap> PKGMAN_PackageInfoURLList := "https://www.gap-system.org";;
 gap> GetPackageURLs();
-Error, PackageManager: GetPackageURLs: bad line:
-<?xml version="1.0" encoding="utf-8"?>
+#I  PackageManager: GetPackageURLs: bad line:
+#I  <?xml version="1.0" encoding="utf-8"?>
+rec( success := false )
 gap> PKGMAN_PackageInfoURLList := default_url;;
 
 # InstallPackage input failure


### PR DESCRIPTION
Most of the `Error` (actually `ErrorNoReturn`) calls in the code
of PackageManager belong to argument checks.
These are fine from the viewpoint of programmatic access to
PackageManager's functions.

The only exceptions are two places in `GetPackageURLs`,
which are reached if either `PKGMAN_DownloadURL` fails
or the downloaded file is corrupted.
These error are problematic for example when Julia code wants to use
PackageManager to install GAP packages at runtime,
see oscar-system/Oscar.jl/issues/1364.

The proposed changes replace the `ErrorNoReturn` calls
by returning the result record with a new component `success`
that is set to `false`.
In the three situations where `GetPackageURLs` is called,
this component gets evaluated.

As far as I see, the documentation need not be changed.
First of all, the function `GetPackageURLs` is undocumented.
The three functions that call it (`InstallPackageFromName`,
`PKGMAN_InstallDependencies`, `UpdatePackage`) do anyhow return
results that indicate failures, and they do not promise error messages
if one is offline.

In order to inform the user about the reason for the failures,
now info messages are printed by `GetPackageURLs`

~~(Would there be any way to *test* the offline behaviour of PackageManager?)~~
(This question has been answered by the test failures after the first commit.)