### PR TITLE
improve the package documentation

### DIFF
--- a/doc/intro.autodoc
+++ b/doc/intro.autodoc
@@ -1,30 +1,29 @@
 @Chapter Introduction
 
-@Section What does the PackageManager package do?
+@Section What does the <Package>PackageManager</Package> package do?
 
 This package provides the ability to install or remove a package using a single
 command: <Ref Func="InstallPackage" /> or <Ref Func="RemovePackage" />.  The
 user can specify a package to install using its name, or using a URL to an
 archive, a repository, or a <C>PackageInfo.g</C> file.  When installing,
-PackageManager also attempts to compile the package, build its documentation if
+<Package>PackageManager</Package> also attempts to compile the package, build its documentation if
 necessary, and ensure that its dependencies are also installed.
 
-@Section What does the PackageManager package not do?
+@Section What does the <Package>PackageManager</Package> package not do?
 
-At present, PackageManager is fairly basic, without many of the advanced
+At present, <Package>PackageManager</Package> is fairly basic, without many of the advanced
 features available in package managers such as pip or apt.  For instance, the
-user cannot install a particular version of a package except by specifying a
-URL; nor can the user update all packages in one command.  Removing a package
+user cannot update all packages in one command.  Removing a package
 will not remove any of its dependencies, since we do not track how packages were
 installed.  When a package is installed, no tests are run to ensure that it is
 compatible with the installed version of GAP.  Any of these features might be
 added in the future.  Other feature requests can be posted on the issue tracker
-at https://github.com/gap-packages/PackageManager/issues.
+at <URL>https://github.com/gap-packages/PackageManager/issues</URL>.
 
 @Section A quick example
 
-To install the latest deposited version of the Digraphs packages, use the
-following:
+To install the latest deposited version of the <Package>Digraphs</Package>
+package, use the following:
 
 @BeginExample
 InstallPackage("digraphs");
@@ -36,8 +35,8 @@ To uninstall it later, use the following:
 RemovePackage("digraphs");
 @EndExample
 
-PackageManager also supports version control repositories.  To install the
-latest version of the curlInterface package from GitHub, use the following:
+<Package>PackageManager</Package> also supports version control repositories.  To install the
+latest version of the <URL Text="curlInterface package from GitHub">https://github.com/gap-packages/curlInterface.git</URL>, use the following:
 
 @BeginExample
 InstallPackage("https://github.com/gap-packages/curlInterface.git");

--- a/gap/PackageManager.gd
+++ b/gap/PackageManager.gd
@@ -1,5 +1,5 @@
 #
-# PackageManager: Easily download and install GAP packages
+# PackageManager: Easily download and install &GAP; packages
 #
 # Declarations
 #
@@ -8,7 +8,7 @@
 #! @Section Installing and updating packages
 
 #! @Description
-#!   Attempts to download and install a package.  The argument `string` should
+#!   Attempts to download and install a package.  The argument <A>string</A> should
 #!   be a string containing one of the following:
 #!     * the name of a package;
 #!     * the URL of a package archive, ending in `.tar.gz` or `.tar.bz2`;
@@ -19,32 +19,33 @@
 #!   The package will then be downloaded and installed, along with any
 #!   additional packages that are required in order for it to be loaded.  Its
 #!   documentation will also be built if necessary.  If this installation is
-#!   successful, or if this package is already installed, `true` is returned;
-#!   otherwise, `false` is returned.
+#!   successful, or if this package is already installed,
+#!   <K>true</K> is returned; otherwise, <K>false</K> is returned.
 #!
-#!   By default, packages will be installed in user's home directory at
-#!   `~/.gap/pkg`.  Note that this location is not the default user pkg location
+#!   By default, packages will be installed in the `pkg` subdirectory of the
+#!   user's home directory, see <Ref BookName="ref" Func="UserHomeExpand"/>.
+#!   Note that this location is not the default user pkg location
 #!   on Mac OSX, but it will be created on any system if not already present.
-#!   Note also that starting GAP with the `-r` flag will cause all packages in
+#!   Note also that starting &GAP; with the `-r` flag will cause all packages in
 #!   this directory to be ignored.
 #!
 #!   Certain decisions, such as installing newer versions of packages, will be
-#!   confirmed by the user via an interactive shell - to avoid this
+#!   confirmed by the user via an interactive shell &ndash; to avoid this
 #!   interactivity and use sane defaults instead, the optional argument
-#!   `interactive` can be set to `false`.
+#!   <A>interactive</A> can be set to <K>false</K>.
 #!
 #!   To see more information about this process while it is ongoing, see
-#!   `InfoPackageManager`.
+#!   <Ref InfoClass="InfoPackageManager"/>.
 #!
-#!   If `string` is the name of the package in question then one can specify
+#!   If <A>string</A> is the name of the package in question then one can specify
 #!   a required package version via a string as value of the optional argument
-#!   `version`, which is interpreted as described in Section
+#!   <A>version</A>, which is interpreted as described in Section
 #!   <Ref Sect="Version Numbers" BookName="ref"/>.
-#!   In particular, if `version` starts with `=` then the
+#!   In particular, if <A>version</A> starts with `=` then the
 #!   function will try to install exactly the given version, and otherwise
 #!   it will try to install a version that is not smaller than the given one.
 #!   If an installed version satisfies the condition on the version then
-#!   `true` is returned without an attempt to upgrade the package.
+#!   <K>true</K> is returned without an attempt to upgrade the package.
 #!   If the package is not yet installed or if no installed version satisfies
 #!   the version condition then an upgrade is tried only if the package version
 #!   that is listed on the &GAP; webpages satisfies the condition.
@@ -60,16 +61,18 @@
 #!
 #! @Arguments string[, version][, interactive]
 #! @Returns
-#!   `true` or `false`
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("InstallPackage");
 
 #! @Description
 #!   Attempts to update an installed package to the latest version.  The first
-#!   argument `name` should be a string specifying the name of a package
-#!   installed in the user GAP root (for example, one installed using <Ref
-#!   Func="InstallPackage" />).  The second argument `interactive` is optional,
+#!   argument <A>name</A> should be a string specifying the name of a package
+#!   installed in the user &GAP; root (for example, one installed using <Ref
+#!   Func="InstallPackage" />),
+#!   see <Ref BookName="ref" Sect="GAP Root Directories"/>.
+#!   The second argument <A>interactive</A> is optional,
 #!   and should be a boolean specifying whether to confirm interactively before
-#!   any directories are deleted (default value `true`).
+#!   any directories are deleted (default value <K>true</K>).
 #!
 #!   If the package was installed via archive, the new version will be installed
 #!   in a new directory, and the old version will be deleted.  If installed via
@@ -81,8 +84,8 @@ DeclareGlobalFunction("InstallPackage");
 #!   example if it needs to be recompiled or if one of its dependencies is
 #!   missing or broken.
 #!
-#!   Returns `true` if a newer version was installed successfully, or if no
-#!   newer version is available.  Returns `false` otherwise.
+#!   Returns <K>true</K> if a newer version was installed successfully, or if no
+#!   newer version is available.  Returns <K>false</K> otherwise.
 #!
 #! @BeginExample
 #! gap> UpdatePackage("io");
@@ -94,25 +97,25 @@ DeclareGlobalFunction("InstallPackage");
 #!
 #! @Arguments name[, interactive]
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("UpdatePackage");
 
 #! @Description
-#!   Attempts to compile an installed package.  Takes one argument `name`, which
+#!   Attempts to compile an installed package.  Takes one argument <A>name</A>, which
 #!   should be a string specifying the name of a package installed in the user
-#!   GAP root (for example, one installed using <Ref Func="InstallPackage" />).
-#!
+#!   &GAP; root (for example, one installed using <Ref Func="InstallPackage" />),
+#!   see <Ref BookName="ref" Sect="GAP Root Directories"/>.
 #!   Compilation is done automatically when a package is installed or updated,
 #!   so in most cases this command is not needed.  However, it may sometimes be
-#!   necessary to recompile some packages if you update or move your GAP
+#!   necessary to recompile some packages if you update or move your &GAP;
 #!   installation.
 #!
 #!   Compilation is done using the `bin/BuildPackages.sh` script included in
-#!   GAP.  If the specified package does not have a compiled component, this
+#!   &GAP;.  If the specified package does not have a compiled component, this
 #!   function should have no effect.
 #!
-#!   Returns `true` if compilation was successful or if no compilation was
-#!   necessary.  Returns `false` otherwise.
+#!   Returns <K>true</K> if compilation was successful or if no compilation was
+#!   necessary.  Returns <K>false</K> otherwise.
 #!
 #! @BeginExample
 #! gap> CompilePackage("orb");
@@ -122,11 +125,11 @@ DeclareGlobalFunction("UpdatePackage");
 #!
 #! @Arguments name
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("CompilePackage");
 
 #! @Description
-#!   Info class for the PackageManager package.  Set this to the following
+#!   Info class for the <Package>PackageManager</Package> package.  Set this to the following
 #!   levels for different levels of information:
 #!     * 0 - No messages
 #!     * 1 - Problems only: messages describing what went wrong, with no
@@ -144,102 +147,106 @@ SetInfoLevel(InfoPackageManager, 3);
 
 #! @Description
 #!   Attempts to download and install a package given only its name.  Returns
-#!   `false` if something went wrong, and `true` otherwise.
+#!   <K>false</K> if something went wrong, and <K>true</K> otherwise.
 #!
 #!   Certain decisions, such as installing newer versions of packages, will be
-#!   confirmed by the user via an interactive shell - to avoid this
+#!   confirmed by the user via an interactive shell &ndash; to avoid this
 #!   interactivity and use sane defaults instead, the optional argument
-#!   `interactive` can be set to `false`.
+#!   <A>interactive</A> can be set to <K>false</K>.
 #!
 #!   A required version can also be specified using the optional argument
-#!   `version`.  It works as described in the <Ref Func="InstallPackage" />
+#!   <A>version</A>.  It works as described in the <Ref Func="InstallPackage" />
 #!   function.
 #! @Arguments name[, version][, interactive]
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("InstallPackageFromName");
 
 #! @Description
-#!   Attempts to download and install a package from a valid PackageInfo.g file.
-#!   The argument `info` should be either a valid package info record, or a URL
-#!   that points to a valid PackageInfo.g file.  Returns `true` if the
-#!   installation was successful, and `false` otherwise.
+#!   Attempts to download and install a package from a valid `PackageInfo.g` file.
+#!   The argument <A>info</A> should be either a valid package info record, or a URL
+#!   that points to a valid `PackageInfo.g` file.  Returns <K>true</K> if the
+#!   installation was successful, and <K>false</K> otherwise.
 #! @Arguments info
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("InstallPackageFromInfo");
 
 #! @Description
 #!   Attempts to download and install a package from an archive located at the
-#!   given URL.  Returns `true` if the installation was successful, and `false`
+#!   given URL.  Returns <K>true</K> if the installation was successful, and <K>false</K>
 #!   otherwise.
 #! @Arguments url
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("InstallPackageFromArchive");
 
 #! @Description
 #!   Attempts to download and install a package from a git repository located at
-#!   the given URL.  Returns `false` if something went wrong, and `true`
+#!   the given URL.  Returns <K>false</K> if something went wrong, and <K>true</K>
 #!   otherwise.
 #!
-#!   If the optional string argument `branch` is specified, this function will
+#!   If the optional string argument <A>branch</A> is specified, this function will
 #!   install the branch with this name.  Otherwise, the repository's default
 #!   branch will be used.
 #!
 #!   Certain decisions, such as installing newer versions of packages, will be
-#!   confirmed by the user via an interactive shell - to avoid this
+#!   confirmed by the user via an interactive shell &ndash; to avoid this
 #!   interactivity and use sane defaults instead, the optional second argument
-#!   `interactive` can be set to `false`.
+#!   <A>interactive</A> can be set to <K>false</K>.
 #! @Arguments url[, interactive][, branch]
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("InstallPackageFromGit");
 
 #! @Description
 #!   Attempts to download and install a package from a Mercurial repository
-#!   located at the given URL.  Returns `false` if something went wrong, and
-#!   `true` otherwise.
+#!   located at the given URL.  Returns <K>false</K> if something went wrong, and
+#!   <K>true</K> otherwise.
 #!
-#!   If the optional string argument `branch` is specified, this function will
+#!   If the optional string argument <A>branch</A> is specified, this function will
 #!   install the branch with this name.  Otherwise, the repository's default
 #!   branch will be used.
 #!
 #!   Certain decisions, such as installing newer versions of packages, will be
-#!   confirmed by the user via an interactive shell - to avoid this
+#!   confirmed by the user via an interactive shell &ndash; to avoid this
 #!   interactivity and use sane defaults instead, the optional second argument
-#!   `interactive` can be set to `false`.
+#!   <A>interactive</A> can be set to <K>false</K>.
 #! @Arguments url[, interactive][, branch]
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("InstallPackageFromHg");
 
 #! @Description
 #!   Attempts to download and install the latest versions of all packages
-#!   required for GAP to run.  Currently these packages are GAPDoc, primgrp,
-#!   SmallGrp, and transgrp.  Returns `false` if something went wrong, and
-#!   `true` otherwise.
+#!   required for &GAP; to run.  Currently these packages are
+#!   <Package>GAPDoc</Package>, <Package>primgrp</Package>,
+#!   <Package>SmallGrp</Package>, and <Package>transgrp</Package>.
+#!   Returns <K>false</K> if something went wrong, and
+#!   <K>true</K> otherwise.
 #!
-#!   Clearly, since these packages are required for GAP to run, they must be
+#!   Clearly, since these packages are required for &GAP; to run, they must be
 #!   loaded before this function can be executed.  However, this function
 #!   installs the packages in the `~/.gap/pkg` directory, so that they can be
-#!   managed by PackageManager in the future, and are available for other GAP
+#!   managed by <Package>PackageManager</Package> in the future, and are available for other &GAP;
 #!   installations on the machine.
 #! @Arguments
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("InstallRequiredPackages");
 
 #! @Section Removing packages
 
 #! @Description
 #!   Attempts to remove an installed package using its name.  The first argument
-#!   `name` should be a string specifying the name of a package installed in the
-#!   user GAP root.  The second argument `interactive` is optional, and should
+#!   <A>name</A> should be a string specifying the name of a package installed in the
+#!   user &GAP; root,
+#!   see <Ref BookName="ref" Sect="GAP Root Directories"/>.
+#!   The second argument <A>interactive</A> is optional, and should
 #!   be a boolean specifying whether to confirm certain decisions interactively
-#!   (default value `true`).
+#!   (default value <K>true</K>).
 #!
-#!   Returns `true` if the removal was successful, and `false` otherwise.
+#!   Returns <K>true</K> if the removal was successful, and <K>false</K> otherwise.
 #!
 #! @BeginExample
 #! gap> RemovePackage("digraphs");
@@ -249,7 +256,7 @@ DeclareGlobalFunction("InstallRequiredPackages");
 #!
 #! @Arguments name[, interactive]
 #! @Returns
-#!   true or false
+#!   <K>true</K> or <K>false</K>
 DeclareGlobalFunction("RemovePackage");
 
 DeclareGlobalFunction("GetPackageURLs");


### PR DESCRIPTION
- introduced some explicit GAPDoc syntax: `<Package>`, `<URL>`, `&GAP;`, `<A>`, `<K>`.

- added some cross-references

- removed the statement from the introduction that PackageManager cannot install a prescribed version of a package