### PR TITLE
Install packages in GAPInfo.UserGapRoot, rather than hard-wire .gap

### DIFF
--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -1057,7 +1057,10 @@ function()
   if PKGMAN_CustomPackageDir <> "" then
     dir := PKGMAN_CustomPackageDir;
   else
-    dir := UserHomeExpand("~/.gap/pkg");  # TODO: cygwin?
+    if GAPInfo.UserGapRoot = fail then
+      ErrorNoReturn("UserGapRoot not set. Cannot determine package directory");
+    fi;
+    dir := Concatenation(GAPInfo.UserGapRoot, "/pkg");
   fi;
   if not IsDirectoryPath(dir) then
     PKGMAN_CreateDirRecursively(dir);


### PR DESCRIPTION
At the moment packagemanager always puts packages in `~/.gap/pkg`. We have a variable, "GAPInfo.UserGapRoot", which is usually `~/.gap`, but can be other values (in particular on windows it is `/Users/name/_gap`).

With this patch, a Windows GAP installer downloaded from github can successfully install packages which don't require compiling (the compiling would in principle work, but then we'd have to package an entire C and C++ compiler...)