### PR TITLE
Stop building curlInterface in test, build in CI instead

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,10 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: "io profiling json"
-          GAPBRANCH: ${{ matrix.gap-branch }}
       - name: 'Install additional dependencies'
         run: |
           packages=(
@@ -47,6 +43,10 @@ jobs:
             libcurl4-openssl-dev
           )
           sudo apt-get install "${packages[@]}"
+      - uses: gap-actions/setup-gap@v2
+        with:
+          GAP_PKGS_TO_BUILD: "io profiling json curlInterface"
+          GAPBRANCH: ${{ matrix.gap-branch }}
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,6 @@ jobs:
           - master
           - stable-4.11
           - stable-4.10
-          - stable-4.9
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 This file describes changes in the PackageManager package.
 
+1.3 (2020-MM-DD)
+  - Require GAP >= 4.10
+  - ...
+
 1.2 (2021-10-02)
   - InstallPackage now supports a required minimum version argument
   - Compatibility changes to re-enable support for GAP 4.9

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,9 @@ This file describes changes in the PackageManager package.
 
 1.3 (2020-MM-DD)
   - Require GAP >= 4.10
-  - ...
+  - Install packages in GAPInfo.UserGapRoot, rather than hard-wire .gap
+  - Improve the package documentation
+  - Improve internal error handling
 
 1.2 (2021-10-02)
   - InstallPackage now supports a required minimum version argument

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -75,7 +75,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.9",
+  GAP := ">= 4.10",
   NeededOtherPackages := [],
   SuggestedOtherPackages := [ [ "GAPDoc", ">= 1.6.1" ], [ "curlInterface", ">= 2.1.0" ] ],
   ExternalConditions := [ ],

--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -12,14 +12,6 @@ if not IsBoundGlobal("InfoGAPDoc") then
   BindGlobal("InfoGAPDoc", fail);
 fi;
 
-# GAP 4.9 doesn't have IsPackageLoaded, so this is for compatibility.
-# IsPackageMarkedForLoading isn't really the same, but is close enough for this.
-if not IsBoundGlobal("IsPackageLoaded") then
-  DeclareGlobalFunction("IsPackageLoaded");
-  InstallGlobalFunction("IsPackageLoaded", 
-                        name -> IsPackageMarkedForLoading(name, ">=0"));
-fi;
-
 InstallGlobalFunction(GetPackageURLs,
 function()
   local get, urls, line, items;

--- a/tst/PackageManager.tst
+++ b/tst/PackageManager.tst
@@ -1,17 +1,4 @@
-# Get curlInterface (for testing)
-gap> InstallPackage("curlInterface");
-true
-gap> if DownloadURL = fail then
->   Unbind(DownloadURL);  # unbind dummy variable set in init.g
-> fi;
 gap> LoadPackage("curlInterface", false);
-true
-
-# Clean up and recompile curlInterface
-gap> dir := PackageInfo("curlInterface")[1].InstallationPath;;
-gap> RemoveDirectoryRecursively(Filename(Directory(dir), "bin"));
-true
-gap> CompilePackage("curlInterface");
 true
 
 # IO should be pre-installed for these tests to pass
@@ -126,6 +113,10 @@ gap> InstallPackage("https://github.com/gap-packages/example/releases/download/v
 true
 gap> ForAny(DirectoryContents(PKGMAN_PackageDir()),
 >           f -> StartsWith(LowercaseString(f), "example"));
+true
+
+# Check package can be recompiled and removed
+gap> CompilePackage("example");
 true
 gap> RemovePackage("example", false);
 true
@@ -331,7 +322,7 @@ false
 # Missing BuildPackages script
 gap> temp := PKGMAN_BuildPackagesScript;;
 gap> PKGMAN_BuildPackagesScript := fail;;
-gap> CompilePackage("curlInterface");
+gap> CompilePackage("example");
 #I  Compilation script not found
 false
 gap> PKGMAN_BuildPackagesScript := temp;;


### PR DESCRIPTION
Stop building and hacking curlinterface during testing. We already test building "example", so this shouldn't reduce coverage.

One thing I don't know and hope @fingolfin might -- how does the package CI know which packages to build? At the moment curlinterface is suggested but not required, but the tests currently always load it.