### PR TITLE
Try to resolve issue 97

### DIFF
--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -238,7 +238,8 @@ end);
 
 InstallGlobalFunction(InstallPackageFromArchive,
 function(url)
-  local get, user_pkg_dir, url_parts, filename, path, exec, files, topdir, dir;
+  local get, user_pkg_dir, url_parts, filename, path, tar, options, exec,
+  files, topdir, dir;
 
   # Download archive
   Info(InfoPackageManager, 3, "Downloading archive from URL ", url, " ...");
@@ -255,8 +256,16 @@ function(url)
   FileString(path, get.result);
   Info(InfoPackageManager, 2, "Saved archive to ", path);
 
+  # Check which version of tar we are using
+  tar := PKGMAN_Exec(".", "tar", "--version");
+  if StartsWith(tar.output, "tar (GNU tar)") then
+    options := "--warning=none";
+  else
+    options := "";
+  fi;
+
   # Check contents
-  exec := PKGMAN_Exec(".", "tar", "--warning=none", "-tf", path);
+  exec := PKGMAN_Exec(".", "tar", options, "-tf", path);
   if exec.code <> 0 then
     Info(InfoPackageManager, 1, "Could not inspect tarball contents");
     return false;


### PR DESCRIPTION
This PR tries to resolve Issue #97 by detecting whether or not `tar` is gnu-tar. Maybe there's a better way of doing this, happy to update as necessary. 

I read your comment @fingolfin:

> However, I think the real problem here is that PKGMAN_Exec deliberately merges stderr and stdout, which breaks here. I have my doubts that this is a good idea in general; it definitely is not here. Perhaps PKGMAN_Exec could get an optional argument which can be used to turn this feature off.

I'm not sure why this is the real problem in this case, the outcome here is more or less the same whether or not the `2&>1` is included, maybe I'm missing something.  "More or less" mean that the installation still fails but the error is just displayed in the terminal instead of being captured in the record that's output by `PKGMAN_Exec`. 

> I think it would be better to never merged stderr into stdout and instead redirect it into a log file.

Also I'm not sure how this can be accomplished in practice using `Process` within `PKGMAN_Exec`, since it doesn't appear to provide a facility for capturing stdout and stderr separately. 