### PR TITLE
Don't set DownloadURL to a dummy value

### DIFF
--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -1162,7 +1162,7 @@ function(url)
   # Use curlInterface if available
   if TestPackageAvailability("curlInterface", PKGMAN_CurlIntReqVer) = true then
     Info(InfoPackageManager, 4, "Using curlInterface to download...");
-    return DownloadURL(url);
+    return ValueGlobal("DownloadURL")(url);
   fi;
 
   # Try command line tools (wget/curl)

--- a/init.g
+++ b/init.g
@@ -4,10 +4,5 @@
 # Reading the declaration part of the package.
 #
 
-# If curlInterface is not loaded, set dummy variable
-if not IsPackageMarkedForLoading("curlInterface", ">=2.1.0") then
-  DownloadURL := fail;
-fi;
-
 ReadPackage("PackageManager", "gap/PackageManager.gd");
 ReadPackage("PackageManager", "gap/Interactive.gd");


### PR DESCRIPTION
Otherwise things break horrible when first doing
`LoadPackage("PackageManager", OnlyNeed)` and then trying to
load curlInterface.
