### PR TITLE
Add The GAP Team as maintainer

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -31,6 +31,13 @@ Persons := [
     Place := "St Andrews",
     Institution := "University of St Andrews",
   ),
+  rec(
+    LastName      := "GAP Team",
+    FirstNames    := "The",
+    IsAuthor      := false,
+    IsMaintainer  := true,
+    Email         := "support@gap-system.org",
+  ),
 ],
 
 SourceRepository := rec(


### PR DESCRIPTION
As I've continued with my education-focused position here in St Andrews, I've not been able to devote as much time to maintaining the package manager as I'd like.  I'm still keen to carry on maintaining and developing it as time allows, but I think we've spotted a few occasions lately when it would've been convenient for others to have "moral permission" to merge PRs and make other changes.

This PR adds "The GAP Team" as a maintainer of the package, in the same style as in the alnuth package.  I hope established GAP developers such as @fingolfin and @ChrisJefferson (and their successors!) will therefore feel welcome to make changes as necessary.

I'm making this a PR so others can check the format.  Does this look about right, @fingolfin?