### PR TITLE
Print BuildPackages.sh output

### DIFF
--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -928,7 +928,10 @@ function(dir)
      PositionSublist(exec.output, "Failed to build") <> fail then
     Info(InfoPackageManager, 1,
          "Compilation failed for package '", info.PackageName, "' (package may still be usable)");
+    Info(InfoPackageManager, 2, exec.output);
     return false;
+  else
+    Info(InfoPackageManager, 3, exec.output);
   fi;
   Info(InfoPackageManager, 4, "Compilation was successful");
   return true;


### PR DESCRIPTION
... if there was a failure at info level 1, and always at info level 3.

This is progress towards resolving #66. IMHO it's not quite there (one should be able to tell PackageManager to not delete the build directories for better debugging). But at least it helps a bit (e.g. it helped me debug PR #108)