### PR TITLE
use a Julia function in `PKGMAN_DownloadURL`

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -88,6 +88,11 @@ Dependencies := rec(
   ExternalConditions := [ ],
 ),
 
+Extensions := [
+    rec( needed := [ [ "JuliaInterface", ">= 0.9.3" ] ],
+         filename := "gap/Download.g" ),
+],
+
 AvailabilityTest := function()
         return true;
     end,

--- a/gap/Download.g
+++ b/gap/Download.g
@@ -1,0 +1,25 @@
+# We know that PackageManager's `PKGMAN_DownloadURL` is already bound
+# when this file gets read.
+# If the GAP session has access to a Julia session,
+# via the Julia package GAP.jl (which we detect from the availability
+# of the GAP package JuliaInterface),
+# then we use the Julia package Downloads.jl for the download.
+# (Note that Downloads.jl gets loaded by GAP.jl.)
+# For that, we replace the code of `PKGMAN_DownloadURL`.
+
+if IsBound(Julia) and JuliaImportPackage("Downloads") = true then
+  MakeReadWriteGlobal("PKGMAN_DownloadURL");
+  UnbindGlobal("PKGMAN_DownloadURL");
+  BindGlobal("PKGMAN_DownloadURL", function(url)
+    local res;
+
+    res := CallJuliaFunctionWithCatch(Julia.Downloads.download,
+               [Julia.string(url), Julia.IOBuffer()]);
+    if res.ok then
+      res := Julia.String(Julia.("take!")(res.value));
+      return rec(success := true, result := JuliaToGAP(IsString, res));
+    else
+      return rec(success := false);
+    fi;
+  end);
+fi;


### PR DESCRIPTION
The Julia package GAP.jl provides an interface between GAP and Julia. It uses PackageManager for installing and loading GAP packages. As soon as GAP has access to a Julia session, a natural way to download files is via the Julia package Downloads.jl.
Therefore, GAP.jl had replaced `PKGMAN_DownloadURL` by a Julia function that uses this approach.

Since pull request https://github.com/gap-system/gap/pull/5375 got merged, we can use its new feature such that the PackageManager package can perform this replacement under the condition that GAP.jl is available in the GAP session.

(The proposed code is simply ignored by versions of GAP that do not yet have the abovementioned feature.)

@fingolfin Do you have perhaps some comments?