### PR TITLE
suppress `Print` output of `ValidatePackageInfo`

### DIFF
--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -846,12 +846,13 @@ function(dir)
   html := Filename(Directory(dir), html);
   # Check for html before full validate
   if not (IsReadableFile(html)
-          and ValidatePackageInfo(info.InstallationPath)) then
+          and ValidatePackageInfo(info.InstallationPath
+                                  : verbose := false)) then
     PKGMAN_MakeDoc(dir);
   fi;
 
   # Ensure valid PackageInfo before proceeding
-  if not ValidatePackageInfo(info.InstallationPath) then
+  if not ValidatePackageInfo(info.InstallationPath : verbose := false) then
     Info(InfoPackageManager, 1, "PackageInfo.g validation failed");
     Info(InfoPackageManager, 2, "(in ", dir, ")");
     if IsPackageLoaded("gapdoc") then
@@ -1237,7 +1238,7 @@ function(url)
   info := PKGMAN_GetPackageInfo(InputTextString(get.result));
 
   # Read the information we want from it
-  if not ValidatePackageInfo(info) then
+  if not ValidatePackageInfo(info : verbose := false) then
     Info(InfoPackageManager, 1, "Invalid PackageInfo.g file");
     return fail;
   fi;

--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -847,12 +847,12 @@ function(dir)
   # Check for html before full validate
   if not (IsReadableFile(html)
           and ValidatePackageInfo(info.InstallationPath
-                                  : verbose := false)) then
+                                  : quiet := true)) then
     PKGMAN_MakeDoc(dir);
   fi;
 
   # Ensure valid PackageInfo before proceeding
-  if not ValidatePackageInfo(info.InstallationPath : verbose := false) then
+  if not ValidatePackageInfo(info.InstallationPath : quiet := true) then
     Info(InfoPackageManager, 1, "PackageInfo.g validation failed");
     Info(InfoPackageManager, 2, "(in ", dir, ")");
     if IsPackageLoaded("gapdoc") then
@@ -1238,7 +1238,7 @@ function(url)
   info := PKGMAN_GetPackageInfo(InputTextString(get.result));
 
   # Read the information we want from it
-  if not ValidatePackageInfo(info : verbose := false) then
+  if not ValidatePackageInfo(info : quiet := true) then
     Info(InfoPackageManager, 1, "Invalid PackageInfo.g file");
     return fail;
   fi;

--- a/tst/PackageManager.tst
+++ b/tst/PackageManager.tst
@@ -460,14 +460,6 @@ gap> PKGMAN_PackageInfoURLList := urllist;;
 
 # Fail to build doc with doc/make_doc (assumes GAP is located at ../../..)
 gap> InstallPackage("https://github.com/gap-packages/grape.git");
-#E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
-elative paths to readable files or directories
-#E  component `HTMLStart' must be bound to a string denoting a relative path t\
-o a readable file
-#E  component `PDFFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `SixFile' must be bound to a string denoting a relative path to \
-a readable file
 #I  PackageInfo.g validation failed
 false
 


### PR DESCRIPTION
Well, set the global option that will suppress this output as soon as GAP supports this option, see gap-system/gap/pull/5766.
(Tests will fail until this happens.)