### PR TITLE
fix `InstallPackage` for prescribed versions

### DIFF
--- a/gap/compile.gi
+++ b/gap/compile.gi
@@ -55,7 +55,9 @@ function(dir)
   if exec = fail or exec.code <> 0 or PositionSublist(exec.output, "Failed to build") <> fail then
     Info(InfoPackageManager, 1, "Compilation failed for package '", info.PackageName, "'");
     Info(InfoPackageManager, 1, "(package may still be usable)");
-    PKGMAN_InfoWithIndent(2, exec.output, 2);
+    if exec <> fail then
+      PKGMAN_InfoWithIndent(2, exec.output, 2);
+    fi;
     return false;
   else
     PKGMAN_InfoWithIndent(3, exec.output, 2);

--- a/gap/packageinfo.gi
+++ b/gap/packageinfo.gi
@@ -1,6 +1,6 @@
 InstallGlobalFunction(InstallPackageFromInfo,
 function(info, version...)
-  local formats, format, url;
+  local equal, formats, format, url;
 
   # Check input
   if not (IsString(info) or IsRecord(info)) then
@@ -16,13 +16,19 @@ function(info, version...)
   fi;
 
   # Check the version condition.
-  if Length(version) = 1 and IsString(version[1])
-      and not CompareVersionNumbers(info.Version, version[1]) then
-    Info(InfoPackageManager, 1, "Version \"", version[1], "\" of package \"",
-         info.PackageName, "\" cannot be satisfied");
-    Info(InfoPackageManager, 2,
-         "The newest version available is ", info.Version);
-    return false;
+  if Length(version) = 1 and IsString(version[1]) then
+    if StartsWith(version[1], "=" ) then
+      equal:= "equal";
+    else
+      equal:= "";
+    fi;
+    if not CompareVersionNumbers(info.Version, version[1], equal) then
+      Info(InfoPackageManager, 1, "Version \"", version[1], "\" of package \"",
+           info.PackageName, "\" cannot be satisfied");
+      Info(InfoPackageManager, 2,
+           "The newest version available is ", info.Version);
+      return false;
+    fi;
   fi;
 
   # Read the information we want from it

--- a/tst/compile.tst
+++ b/tst/compile.tst
@@ -5,7 +5,7 @@ false
 
 # Try to compile something that's not there at all
 gap> CompilePackage("madeUpPackage");
-#I  Package "madeuppackage" not installed in user package directory
+#I  Package "madeUpPackage" not installed in user package directory
 false
 
 # Check package can be recompiled and removed


### PR DESCRIPTION
If an exact version number (one starting with `=`) is prescribed in `InstallPackage`, the exactness was ignored up to now. With this change, an available package version with larger version number is not regarded as matching the version condition in this case, and the return value is `false`.

This affects `InstallPackageByName` and `InstallPackageByInfo`. (The possibility to prescribe a version number in the latter function is in fact not documented.)

The problem had been observed already in issue #114. Its discussion makes clear that (currently) PackageManager cannot access arbitrary older versions of GAP packages. My understanding is that `InstallPackage` must return `false` if an exact version number is requested and if if this version cannot be made available.
Should the documentation be made clearer in this respect?

Sorry for the inconveniences, in particular for not reacting earlier.
The reason for the bug was a wrong usage of GAP's `CompareVersionNumbers`.
(All code involving this function could be simplified if this function would deal with the meaning of version numbers starting with `=`.)