### PR TITLE
Move recent "Example" package tests to RecentGapOnly

### DIFF
--- a/tst/compile.tst
+++ b/tst/compile.tst
@@ -8,69 +8,24 @@ gap> CompilePackage("madeUpPackage");
 #I  Package "madeUpPackage" not installed in user package directory
 false
 
-# Check package can be recompiled and removed
-gap> InstallPackage("example");
-true
-gap> CompilePackage("example");
-true
-gap> RemovePackage("example", false);
-true
-
 # CompilePackage bad input
 gap> CompilePackage(3);
 Error, <name> must be a string
 gap> CompilePackage(true);
 Error, <name> must be a string
 
-# PKGMAN_CompileDir error: no shell
-gap> InstallPackage("example");
-true
-gap> InstallPackage("example");  # latest version already installed
-true
-gap> progs := GAPInfo.DirectoriesPrograms;;
-gap> GAPInfo.DirectoriesPrograms := [];;  # terrible vandalism
-gap> dir := PKGMAN_UserPackageInfo("example")[1].InstallationPath;;
-gap> PKGMAN_CompileDir(dir);
-#I  No shell available called "sh"
-#I  Compilation failed for package 'Example'
-#I  (package may still be usable)
-false
-gap> GAPInfo.DirectoriesPrograms := progs;;
-
-# PKGMAN_CompileDir error: no etc/BuildPackages.sh
-gap> InstallPackage("example", false);
-true
-gap> sysinfo_scr := PKGMAN_Sysinfo;;
-gap> PKGMAN_Sysinfo := fail;;
-gap> dir := PKGMAN_UserPackageInfo("example")[1].InstallationPath;;
-gap> PKGMAN_CompileDir(dir);
-#I  No sysinfo.gap found
-false
-gap> PKGMAN_Sysinfo := sysinfo_scr;;
-
-# PKGMAN_CompileDir error: missing source
-gap> InstallPackage("example");
-true
-gap> dir := PKGMAN_UserPackageInfo("example")[1].InstallationPath;;
-gap> RemoveFile(Filename(Directory(dir), "src/hello.c"));
-true
-gap> PKGMAN_CompileDir(dir);
-#I  Compilation failed for package 'Example'
-#I  (package may still be usable)
-false
-
-# Missing BuildPackages script
-gap> temp := PKGMAN_BuildPackagesScript;;
-gap> PKGMAN_BuildPackagesScript := fail;;
-gap> CompilePackage("example");
-#I  Compilation script not found
-false
-gap> PKGMAN_BuildPackagesScript := temp;;
-gap> RemovePackage("example", false);
-true
-
 # Compile already compiled
 gap> InstallPackage("toric");
 true
 gap> CompilePackage("toric");
+true
+
+# Missing BuildPackages script
+gap> temp := PKGMAN_BuildPackagesScript;;
+gap> PKGMAN_BuildPackagesScript := fail;;
+gap> CompilePackage("toric");
+#I  Compilation script not found
+false
+gap> PKGMAN_BuildPackagesScript := temp;;
+gap> RemovePackage("toric", false);
 true

--- a/tst/git.tst
+++ b/tst/git.tst
@@ -4,22 +4,6 @@ true
 gap> LoadPackage("autodoc", false);
 true
 
-# Install a package from a git repository, and modify it
-gap> InstallPackage("https://github.com/gap-packages/Example.git");
-true
-gap> dir := First(DirectoryContents(PKGMAN_PackageDir()),
->                 f -> StartsWith(f, "Example"));;
-gap> dir := Filename(Directory(PKGMAN_PackageDir()), dir);;
-gap> dir <> fail;
-true
-gap> readme := Filename(Directory(dir), "README.md");;
-gap> FileString(readme, "Some change I've made", true);;  # edit file
-gap> UpdatePackage("example");
-#I  Uncommitted changes in git repository
-false
-gap> RemovePackage("example", false);
-true
-
 # Install a package from a git repository by branch
 gap> InstallPackageFromGit("https://github.com/gap-packages/MathInTheMiddle.git", false, "master");
 true


### PR DESCRIPTION
The 4.12 tests are failing due to the Example package not having an "accepted", "deposited", etc. status.  This requirement has been relaxed in recent versions, so it's not something we're worried about going forward.

I've moved the offending tests to `RecentGapOnly.tst`, which means it'll still be run on stable-4.14 and master, which are more forgiving.