### PR TITLE
adjust to GAP 4.14

### DIFF
--- a/gap/PackageManager.gd
+++ b/gap/PackageManager.gd
@@ -20,8 +20,9 @@
 #!   successful, or if this package is already installed,
 #!   <K>true</K> is returned; otherwise, <K>false</K> is returned.
 #!
-#!   By default, packages will be installed in the `pkg` subdirectory of the
-#!   user's home directory, see <Ref BookName="ref" Func="UserHomeExpand"/>.
+#!   By default, packages will be installed in the `pkg` subdirectory of
+#!   <C>GAPInfo.UserGapRoot</C>,
+#!   see <Ref BookName="ref" Sect="GAP Root Directories"/>,
 #!   Note that this location is not the default user pkg location
 #!   on Mac OSX, but it will be created on any system if not already present.
 #!   Note also that starting &GAP; with the `-r` flag will cause all packages in

--- a/gap/directories.gi
+++ b/gap/directories.gi
@@ -18,9 +18,6 @@ end);
 
 InstallGlobalFunction(PKGMAN_SetCustomPackageDir,
 function(dir)
-  if not (EndsWith(dir, "/pkg") or EndsWith(dir, "/pkg/")) then
-    return fail;
-  fi;
   # Set the variable
   PKGMAN_CustomPackageDir := dir;
   # Create the directory if necessary
@@ -56,6 +53,21 @@ end);
 InstallGlobalFunction(PKGMAN_InsertPackageDirectory,
 function(pkgpath)
   local parent;
+
+  if IsBound(ExtendPackageDirectories) then
+    # GAP 4.14 or newer
+    parent:= Directory(pkgpath);
+    if not parent in GAPInfo.PackageDirectories then
+      GAPInfo.PackageDirectories:= Concatenation([parent], GAPInfo.PackageDirectories);
+    fi;
+    if IsBound(GAPInfo.PackagesInfoInitialized) and GAPInfo.PackagesInfoInitialized then
+      GAPInfo.PackagesInfoInitialized := false;
+      InitializePackagesInfoRecords();
+    fi;
+    return;
+  fi;
+
+  # The following code deals with GAP 4.13 or older.
   # Locate the parent directory
   if EndsWith(pkgpath, "/pkg") then
     parent := pkgpath{[1 .. Length(pkgpath) - 3]};

--- a/tst/directories.tst
+++ b/tst/directories.tst
@@ -24,7 +24,3 @@ gap> PKGMAN_CustomPackageDir := "";;
 gap> EndsWith(PKGMAN_PackageDir(), "/.gap/pkg");
 true
 gap> PKGMAN_CustomPackageDir := olddir;;
-gap> PKGMAN_SetCustomPackageDir("/home");  # not ending in pkg
-fail
-gap> PKGMAN_InsertPackageDirectory("/home");  # not ending in pkg
-fail


### PR DESCRIPTION
- adjust `PKGMAN_InsertPackageDirectory`: in GAP 4.14, it must modify `GAPInfo.PackageDirectories`
- adjust `PKGMAN_SetCustomPackageDir`: we cannot assume that the paths of package directories end with `pkg`
- removed the `PKGMAN_SetCustomPackageDir` tests for the `pkg` suffix
- fix the statement about the default location for the package installations

After these changes, the test suite runs without complaints when I run it locally.

The changes do *not* address the problem

> `InstallPackage` with a git URL and `CompilePackage` fail if the gap was started with a non-trivial `--packagedirs` value

that is described in github.com/gap-system/gap/issues/5916.

As far as I see, this is an instance of the general feature that `InstallPackage` does not compile a newly installed package if the same version of that package was already installed in another package directory; this was already the case before the introduction of the `--packagedirs` option.
(When one installs a package via its git URL then it will get cloned, and the documentation gets built, but if the same version of the package was already available before then the newly downloaded version will not get compiled.)
