### PR TITLE
Compile packages more liberally

### DIFF
--- a/gap/PackageManager.gi
+++ b/gap/PackageManager.gi
@@ -228,11 +228,10 @@ function(dir)
     Info(InfoPackageManager, 1, "There may be problems with the package");
   fi;
 
-  # Compile if needed
-  PKGMAN_RefreshPackageInfo();
-  if TestPackageAvailability(info.PackageName, info.Version) = fail then
-    PKGMAN_CompileDir(dir);
-  fi;
+  # Attempt to compile.
+  # This will often be unnecessary, but it's hard to tell whether compilation
+  # has already been done, and recompiling is usually cheap.
+  PKGMAN_CompileDir(dir);
 
   # Redo dependencies if needed
   if TestPackageAvailability(info.PackageName, info.Version) = fail then

--- a/tst/RecentGapOnly.tst
+++ b/tst/RecentGapOnly.tst
@@ -4,11 +4,14 @@ true
 gap> LoadPackage("autodoc", false);
 true
 
-# Fail to build doc but completes installation (assumes GAP is located at ../../..)
+# Fail to build doc and compile but completes installation
+# (assumes GAP is located at ../../..)
 # Prints lots of #E messages in GAP 4.13 and earlier
 gap> InstallPackage("https://github.com/gap-packages/grape.git");
 #I  PackageInfo.g validation failed
 #I  There may be problems with the package
+#I  Compilation failed for package 'GRAPE'
+#I  (package may still be usable)
 true
 
 # Interactive tests (via hacking in/out streams)
@@ -219,4 +222,31 @@ gap> UpdatePackage("example");
 #I  Uncommitted changes in git repository
 false
 gap> RemovePackage("example", false);
+true
+
+# Checking package: always compile even when another version is already installed
+gap> InstallPackage("orb");
+true
+gap> InstallPackage("https://github.com/gap-packages/orb.git");
+Extracting manual examples for orb package ...
+11 chapters detected
+Chapter 1 : no examples 
+Chapter 2 : no examples 
+Chapter 3 : extracted 2 examples
+Chapter 4 : no examples 
+Chapter 5 : no examples 
+Chapter 6 : no examples 
+Chapter 7 : extracted 1 examples
+Chapter 8 : no examples 
+Chapter 9 : no examples 
+Chapter 10 : no examples 
+Chapter 11 : no examples 
+true
+gap> git_pkginfo := First(PackageInfo("orb"), p -> EndsWith(p.InstallationPath, "orb/"));;
+gap> "bin" in DirectoryContents(git_pkginfo.InstallationPath);  # check if it has been compiled
+true
+gap> RemoveDirectoryRecursively(git_pkginfo.InstallationPath);  # delete git version
+true
+gap> PKGMAN_RefreshPackageInfo();
+gap> RemovePackage("orb", false);  # delete release version
 true

--- a/tst/git.tst
+++ b/tst/git.tst
@@ -26,14 +26,16 @@ gap> InstallPackageFromGit("https://github.com/a/b.git", true, "master", "lol");
 Error, requires 1, 2 or 3 arguments (not 4)
 
 # Install a package from a git repository not ending in .git
-gap> InstallPackageFromGit("https://github.com/gap-packages/RegisterPackageTNUMDemo", false);
+gap> InstallPackageFromGit("https://github.com/gap-packages/MathInTheMiddle", false);
 true
 gap> ForAny(DirectoryContents(PKGMAN_PackageDir()),
->           f -> StartsWith(f, "RegisterPackageTNUMDemo"));
+>           f -> StartsWith(f, "MathInTheMiddle"));
 true
-gap> InstallPackageFromGit("https://github.com/gap-packages/RegisterPackageTNUMDemo", false);
+gap> InstallPackageFromGit("https://github.com/gap-packages/MathInTheMiddle", false);
 #I  Package already installed at target location
 false
+gap> RemovePackage("MathInTheMiddle", false);
+true
 
 # Repositories that don't contain GAP packages
 gap> InstallPackageFromGit("https://github.com/mtorpey/planets.git", true);


### PR DESCRIPTION
When we install a new package, we have generally tried to check whether it can be loaded before attempting compilation.  This has problems, including the fourth box [here](https://github.com/gap-system/gap/issues/5916#issuecomment-2630520997) and @ThomasBreuer's comment in #140 where having two different installations of the same version of the same package means the newer one won't be compiled on installation.

It's actually quite cheap to run the package build script, and the occasional recompile shouldn't be something we worry too much about.  So compilation is now run inside `PKGMAN_CheckPackage` which will always be executed when a new package is installed.

The test suite has gone from 1m37s to 1m43s on my computer, indicating not too big a performance hit!